### PR TITLE
Use /opt/mesosphere/bin/curl for GCE ip_detect script

### DIFF
--- a/dcos_test_utils/ip-detect/gce.sh
+++ b/dcos_test_utils/ip-detect/gce.sh
@@ -3,4 +3,4 @@
 # Uses the GCE metadata server to get the node's internal
 # ipv4 address
 
-curl -fsSL -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/ip
+/opt/mesosphere/bin/curl -fsSL -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/ip

--- a/dcos_test_utils/ip-detect/gce_public.sh
+++ b/dcos_test_utils/ip-detect/gce_public.sh
@@ -3,4 +3,4 @@
 # Uses the GCE metadata server to get the node's external
 # ipv4 address
 
-curl -fsSL -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip
+/opt/mesosphere/bin/curl -fsSL -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip


### PR DESCRIPTION
Use /opt/mesosphere/bin/curl for GCE ip_detect script to avoid linking issues on certain images.